### PR TITLE
[R22.1] [NF-5295 NF-5218] Fix slider for floating point values with low min/max delta

### DIFF
--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -308,8 +308,8 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
     return Math.min(1, parseFloat(normalizedStepSize));
   };
 
-  const step = max - min <= 1 ? stepHeuristic(min, max) : 1;
-
+  const allInteger = Number.isInteger(min) && Number.isInteger(max);
+  const step = allInteger ? 1 : stepHeuristic(min, max);
   return (
     <FilterPluginStyle height={height} width={width}>
       {Number.isNaN(Number(min)) || Number.isNaN(Number(max)) ? (


### PR DESCRIPTION
This PR fixes an issue in the numerical range filter(slide) that occurs when the filter values are decimals where the delta between the min and max value is low. Now we use decimal steps i.e 0.1 when the min-max delta is below 20 to allow increased granularity.

Example:
![Screenshot 2025-03-10 at 12 14 00](https://github.com/user-attachments/assets/eed36be2-b973-4149-9d00-b536e22c0673)
