### PR TITLE
[R22.1] [NF-5220 NF-5221] Remove patient profile from export and start exports counting from 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,5 @@ under the License.
 - [4.0.0](./CHANGELOG/4.0.0.md)
 - [4.0.1](./CHANGELOG/4.0.1.md)
 - [4.0.2](./CHANGELOG/4.0.2.md)
+
+[NephroFlow](./CHANGELOG/NEPHROFLOW.md)

--- a/CHANGELOG/NEPHROFLOW.md
+++ b/CHANGELOG/NEPHROFLOW.md
@@ -1,0 +1,43 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Breaking changes
+
+### Added
+
+- Added a flag to ignore certain columns in xlsx & csv exports. (Key: TABLE_EXPORT_IGNORE_COLS) [NF-5220](https://www.notion.so/nipro-digital/Remove-the-link-to-the-patient-s-file-from-the-data-exports-1a444b771c6c8063a7fce88ef0f3968c)
+
+### Changed
+
+- Xlsx exports start counting from 1 instead of 0. [NF-5221](https://www.notion.so/nipro-digital/Start-exports-starting-from-1-in-stead-of-0-1a444b771c6c8012a29bc0e12f5e9df4)
+
+### Removed
+
+### Fixed
+
+- Allow decimal steps in range sliders for smaller values. [NF-5295](https://www.notion.so/nipro-digital/PHM-QI-does-not-filter-on-float-numbers-1ab44b771c6c80c2b93ad50cf3d78fcb) [NF-5218](https://www.notion.so/nipro-digital/Adjust-the-slider-min-max-values-to-allow-for-0-1-steps-1a444b771c6c80b9b8d1d96abac08827)

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -626,12 +626,23 @@ class QueryContextProcessor:
                 df.columns = [verbose_map.get(column, column) for column in columns]
 
             result = None
+            columns_to_include = [
+                col
+                for col in df.columns
+                if col not in config["TABLE_EXPORT_IGNORE_COLS"]
+            ]
             if self._query_context.result_format == ChartDataResultFormat.CSV:
                 result = csv.df_to_escaped_csv(
-                    df, index=include_index, **config["CSV_EXPORT"]
+                    df,
+                    columns=columns_to_include,
+                    index=include_index,
+                    **config["CSV_EXPORT"],
                 )
             elif self._query_context.result_format == ChartDataResultFormat.XLSX:
-                result = excel.df_to_excel(df, **config["EXCEL_EXPORT"])
+                df.index += 1
+                result = excel.df_to_excel(
+                    df, columns=columns_to_include, **config["EXCEL_EXPORT"]
+                )
             return result or ""
 
         return df.to_dict(orient="records")

--- a/superset/config.py
+++ b/superset/config.py
@@ -780,6 +780,9 @@ CSV_EXPORT = {"encoding": "utf-8"}
 # note: index option should not be overridden
 EXCEL_EXPORT: dict[str, Any] = {}
 
+# The columns to ignore when exporting a table. These columns will not be added to the csv/xlsx
+TABLE_EXPORT_IGNORE_COLS = []
+
 # ---------------------------------------------------
 # Time grain configurations
 # ---------------------------------------------------


### PR DESCRIPTION
This PR adjust the table like exports in Superset:
1. Support ignoring columns based on config values. (Key: TABLE_EXPORT_IGNORE_COLS)
2. Start index counting from 1 instead of 0

Example:
![Screenshot 2025-03-10 at 15 01 16](https://github.com/user-attachments/assets/b6a62137-f14c-4ce6-8477-b96994b9ee1b)
