### PR TITLE
[R22.1] [NF-5222] Serialize full sql error mesage in SQL Lab

### DIFF
--- a/CHANGELOG/NEPHROFLOW.md
+++ b/CHANGELOG/NEPHROFLOW.md
@@ -41,3 +41,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow decimal steps in range sliders for smaller values. [NF-5295](https://www.notion.so/nipro-digital/PHM-QI-does-not-filter-on-float-numbers-1ab44b771c6c80c2b93ad50cf3d78fcb) [NF-5218](https://www.notion.so/nipro-digital/Adjust-the-slider-min-max-values-to-allow-for-0-1-steps-1a444b771c6c80b9b8d1d96abac08827)
+- Serialize full error message in SQL Lab. [NF-5222](https://www.notion.so/Improve-readability-of-the-error-messages-1a444b771c6c80918721cfaf70952b5d?pvs=8&n=github_linkback) 

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -76,9 +76,6 @@ COLUMN_DOES_NOT_EXIST_REGEX = re.compile(
     r"does not exist\s+LINE (?P<location>\d+?)"
 )
 
-SYNTAX_ERROR_REGEX = re.compile('syntax error at or near "(?P<syntax_error>.*?)"')
-
-
 def parse_options(connect_args: dict[str, Any]) -> dict[str, str]:
     """
     Parse ``options`` from  ``connect_args`` into a dictionary.
@@ -160,14 +157,6 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
                 "line %(location)s.",
             ),
             SupersetErrorType.COLUMN_DOES_NOT_EXIST_ERROR,
-            {},
-        ),
-        SYNTAX_ERROR_REGEX: (
-            __(
-                "Please check your query for syntax errors at or "
-                'near "%(syntax_error)s". Then, try running your query again.'
-            ),
-            SupersetErrorType.SYNTAX_ERROR,
             {},
         ),
     }


### PR DESCRIPTION
This change removes the regex that is used to find postgersql syntax errors .

I decided to remove the regex completely as it would only match to the first line of the error and all necessary information is already included in the original error message so there is no need to adjust it.